### PR TITLE
light_valgrind/ci: fix previous step name in "Prepare artifact: light…

### DIFF
--- a/.github/workflows/devshell_light_valgrind.yml
+++ b/.github/workflows/devshell_light_valgrind.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: "Prepare artifact: light-reports"
         id: prepare-light-reports
-        if: always() && steps.light.outcome == 'failure'
+        if: always() && steps.light-valgrind-check.outcome != 'skipped'
         run: |
           REPORTS_DIR=$GITHUB_WORKSPACE/tests/light/reports
           cp -r ${REPORTS_DIR} /tmp/light-reports


### PR DESCRIPTION
…-reports" step

- without this step not executed

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
